### PR TITLE
feat: Implement database connection pooling for concurrency

### DIFF
--- a/db.py
+++ b/db.py
@@ -4,9 +4,14 @@ from flask.cli import with_appcontext
 import os
 import psycopg2
 from psycopg2.extras import DictCursor
+from psycopg2.pool import SimpleConnectionPool
 import sqlite3
 import datetime
 import re
+import atexit
+
+# Variable global para el pool de conexiones
+pool = None
 
 # --- Adaptadores y Conversores para SQLite ---
 # Soluciona DeprecationWarning en Python 3.12+ para timestamps.
@@ -25,95 +30,110 @@ sqlite3.register_converter("timestamp", convert_timestamp)
 def get_db():
     """
     Obtiene una conexión a la base de datos para la solicitud actual.
-    Se conecta a SQLite si la app está en modo de prueba (TESTING=True).
-    De lo contrario, se conecta a PostgreSQL usando DATABASE_URL.
+    Si hay un pool de conexiones (PostgreSQL), obtiene una conexión de él.
+    Si no, crea una conexión a SQLite para pruebas.
     """
     if 'db' not in g:
-        database_url = current_app.config.get('DATABASE_URL')
-        if database_url:
-            # Priorizar DATABASE_URL si está disponible (para pruebas en PostgreSQL)
-            g.db = psycopg2.connect(database_url, cursor_factory=DictCursor)
+        if pool:
+            # Obtener conexión del pool para PostgreSQL
+            g.db = pool.getconn()
         elif current_app.config.get('TESTING'):
-            # Fallback a SQLite si TESTING es True pero no hay DATABASE_URL
+            # Conexión a SQLite para pruebas
             db_path = current_app.config.get('DATABASE')
             if not db_path:
                 raise RuntimeError("La configuración 'DATABASE' es necesaria para las pruebas con SQLite.")
             g.db = sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES)
             g.db.row_factory = sqlite3.Row
         else:
-            # Conexión de producción
-            prod_db_url = os.environ.get('DATABASE_URL')
-            if not prod_db_url:
-                raise RuntimeError("DATABASE_URL no está configurada para producción.")
-            g.db = psycopg2.connect(prod_db_url, cursor_factory=DictCursor)
+            # Esto no debería ocurrir en un entorno de producción bien configurado
+            raise RuntimeError("El pool de conexiones de la base de datos no está inicializado.")
     
     return g.db
 
 def close_db(e=None):
     """
-    Cierra la conexión a la base de datos si existe.
-    Esta función se registra para que Flask la llame automáticamente al final
-    de cada solicitud, asegurando que la conexión a la base de datos siempre se cierre
-    correctamente, incluso si ocurre un error durante el procesamiento de la solicitud.
+    Cierra la conexión a la base de datos.
+    Si la conexión vino del pool, la devuelve al pool.
+    Si es una conexión SQLite, la cierra.
     """
     db = g.pop('db', None)
 
     if db is not None:
-        db.close()
+        if pool and not isinstance(db, sqlite3.Connection):
+            # Devolver la conexión al pool
+            pool.putconn(db)
+        else:
+            # Cerrar la conexión (para SQLite)
+            db.close()
 
 def init_db():
     """
     Inicializa la base de datos ejecutando el script SQL del archivo 'schema.sql'.
-    Este script crea todas las tablas y la estructura necesaria para la aplicación.
-    Maneja la diferencia en la ejecución de scripts entre SQLite y PostgreSQL.
     """
     db = get_db()
-    with current_app.open_resource('schema.sql') as f:
-        sql_script = f.read().decode('utf8')
+    try:
+        with current_app.open_resource('schema.sql') as f:
+            sql_script = f.read().decode('utf8')
 
-    # sqlite3 connection objects tienen 'executescript', psycopg2 no.
-    # Usamos esto para determinar el tipo de conexión y ejecutar el script apropiadamente.
-    if hasattr(db, 'executescript'):
-        # Conexión SQLite (usada en pruebas)
-        db.executescript(sql_script)
-    else:
-        # Conexión PostgreSQL (usada en producción)
-        with db.cursor() as cursor:
-            # Limpiar comentarios y dividir el script en sentencias
-            # Eliminar comentarios de línea (-- ...)
-            clean_script = re.sub(r'--.*$', '', sql_script, flags=re.MULTILINE)
-            statements = [statement.strip() for statement in clean_script.split(';') if statement.strip()]
+        if hasattr(db, 'executescript'):
+            # Conexión SQLite
+            db.executescript(sql_script)
+        else:
+            # Conexión PostgreSQL
+            with db.cursor(cursor_factory=DictCursor) as cursor:
+                clean_script = re.sub(r'--.*$', '', sql_script, flags=re.MULTILINE)
+                statements = [statement.strip() for statement in clean_script.split(';') if statement.strip()]
 
-            for statement in statements:
-                cursor.execute(statement)
-        db.commit()
+                for statement in statements:
+                    cursor.execute(statement)
+            db.commit()
+    finally:
+        # Asegurarse de que la conexión se devuelva/cierre después de la inicialización
+        close_db()
 
 @click.command('init-db')
 @with_appcontext
 def init_db_command():
-    """
-    Define un comando de terminal 'flask init-db' para inicializar la base de datos.
-    Esto permite crear la base de datos desde la línea de comandos de una manera sencilla y estandarizada.
-    @with_appcontext asegura que el contexto de la aplicación esté disponible, permitiendo
-    el uso de 'current_app'.
-    """
+    """Define un comando de terminal 'flask init-db' para inicializar la base de datos."""
     init_db()
     click.echo('Base de datos inicializada.')
 
 def init_app(app):
     """
     Registra las funciones de la base de datos con la instancia de la aplicación Flask.
-    Esta función es llamada por la fábrica de aplicaciones en app.py.
+    Inicializa el pool de conexiones para PostgreSQL si se proporciona una DATABASE_URL.
     """
+    global pool
+    database_url = app.config.get('DATABASE_URL') or os.environ.get('DATABASE_URL')
+
+    if database_url:
+        try:
+            # Inicializar el pool. minconn=1, maxconn=15.
+            # Se crea tanto para producción como para pruebas si DATABASE_URL está presente.
+            pool = SimpleConnectionPool(1, 15, dsn=database_url)
+            # Registrar una función para cerrar el pool cuando la app termine
+            atexit.register(close_pool)
+            app.logger.info("Pool de conexiones a PostgreSQL inicializado.")
+        except psycopg2.OperationalError as e:
+            app.logger.error(f"No se pudo conectar a la base de datos y crear el pool: {e}")
+            pool = None
+
     app.teardown_appcontext(close_db)
     app.cli.add_command(init_db_command)
+
+def close_pool():
+    """Cierra todas las conexiones en el pool."""
+    global pool
+    if pool:
+        pool.closeall()
+        # No se puede usar current_app.logger aquí porque el contexto de la app puede no estar disponible
+        print("Pool de conexiones a PostgreSQL cerrado.")
 
 def log_action(accion, usuario_id, tipo_objeto, objeto_id, detalles=None):
     """
     Registra una acción de auditoría en la base de datos.
     """
     db = get_db()
-    # Asumimos que si estamos usando esta función, la BD soporta %s
     sql = """
         INSERT INTO auditoria_acciones (usuario_id, accion, tipo_objeto, objeto_id, detalles)
         VALUES (%s, %s, %s, %s, %s)
@@ -121,10 +141,9 @@ def log_action(accion, usuario_id, tipo_objeto, objeto_id, detalles=None):
     params = (usuario_id, accion, tipo_objeto, objeto_id, detalles)
 
     try:
-        cursor = db.cursor()
-        cursor.execute(sql, params)
+        with db.cursor(cursor_factory=DictCursor) as cursor:
+            cursor.execute(sql, params)
         db.commit()
-        cursor.close()
     except Exception as e:
         current_app.logger.error(f"Error al registrar acción de auditoría: {accion} por {usuario_id} - {e}")
         db.rollback()


### PR DESCRIPTION
Refactored the database management in `db.py` to use a connection pool, addressing the core requirement of supporting multiple simultaneous users.

Key changes:
- Replaced the per-request database connection logic with a `psycopg2.pool.SimpleConnectionPool`.
- The connection pool is initialized once when the Flask application starts.
- The `get_db` function now retrieves a connection from the pool.
- The `close_db` function now returns the connection to the pool for reuse.
- The pool is gracefully closed when the application exits using the `atexit` module.
- The changes are compatible with the existing test suite, which uses a PostgreSQL database for testing.

This change allows the application to handle database connections efficiently, preventing performance bottlenecks and connection errors under concurrent load, and enabling it to support multiple users as requested.